### PR TITLE
Fixed a problem with FreeBSD 13.2

### DIFF
--- a/ARM/main.json
+++ b/ARM/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "3148364804582012665"
+      "version": "0.27.1.19265",
+      "templateHash": "10894490779963359175"
     }
   },
   "parameters": {
@@ -246,8 +246,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "10404007908853839367"
+              "version": "0.27.1.19265",
+              "templateHash": "7618456689992419905"
             }
           },
           "parameters": {
@@ -311,8 +311,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "3233476498097323781"
+              "version": "0.27.1.19265",
+              "templateHash": "10096597440913624342"
             }
           },
           "parameters": {
@@ -395,8 +395,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "3585621987444271924"
+              "version": "0.27.1.19265",
+              "templateHash": "7244627767521530974"
             }
           },
           "parameters": {
@@ -568,8 +568,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "455565827775590263"
+              "version": "0.27.1.19265",
+              "templateHash": "17301415359303189388"
             }
           },
           "parameters": {
@@ -730,8 +730,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "455565827775590263"
+              "version": "0.27.1.19265",
+              "templateHash": "17301415359303189388"
             }
           },
           "parameters": {
@@ -875,8 +875,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "2240641579897424295"
+              "version": "0.27.1.19265",
+              "templateHash": "13030012561888164045"
             }
           },
           "parameters": {
@@ -1043,8 +1043,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -1164,8 +1164,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -1340,8 +1340,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "2240641579897424295"
+              "version": "0.27.1.19265",
+              "templateHash": "13030012561888164045"
             }
           },
           "parameters": {
@@ -1508,8 +1508,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -1629,8 +1629,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -1806,8 +1806,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "2240641579897424295"
+              "version": "0.27.1.19265",
+              "templateHash": "13030012561888164045"
             }
           },
           "parameters": {
@@ -1974,8 +1974,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -2095,8 +2095,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {
@@ -2257,8 +2257,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "10404007908853839367"
+              "version": "0.27.1.19265",
+              "templateHash": "7618456689992419905"
             }
           },
           "parameters": {
@@ -2334,8 +2334,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "3585621987444271924"
+              "version": "0.27.1.19265",
+              "templateHash": "7244627767521530974"
             }
           },
           "parameters": {
@@ -2405,8 +2405,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "3680694001776717420"
+              "version": "0.27.1.19265",
+              "templateHash": "16742150259400364869"
             }
           },
           "parameters": {
@@ -2471,8 +2471,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "9604163246042588806"
+              "version": "0.27.1.19265",
+              "templateHash": "17908906777574127410"
             }
           },
           "parameters": {
@@ -2540,8 +2540,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "3233100027539142300"
+              "version": "0.27.1.19265",
+              "templateHash": "482445361103659593"
             }
           },
           "parameters": {
@@ -2650,8 +2650,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11556493485978040668"
+                      "version": "0.27.1.19265",
+                      "templateHash": "4877864072155141273"
                     }
                   },
                   "parameters": {

--- a/ARM/uiFormDefinition.json
+++ b/ARM/uiFormDefinition.json
@@ -112,15 +112,15 @@
               "name": "OpnVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "OPNSense Version to deploy",
-              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
-              "defaultValue": "23.7"
+              "toolTip": "OPNsense Releases. Latest: 24.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
+              "defaultValue": "24.1"
             },
             {
               "name": "WALinuxVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "Azure WALinux agent Version",
-              "toolTip": "Azure WALinux agent Releases. Only version number, dont add v at the begining. Latest: 2.9.0.4, 2.9.1.1 Reference: https://github.com/Azure/WALinuxAgent/releases",
-              "defaultValue": "2.9.1.1"
+              "toolTip": "Azure WALinux agent Releases. Only version number, dont add v at the begining. Latest: 2.10.0.8, 2.9.1.1 Reference: https://github.com/Azure/WALinuxAgent/releases",
+              "defaultValue": "2.10.0.8"
             },
             {
               "name": "DeployWindows",

--- a/bicep/uiFormDefinition.json
+++ b/bicep/uiFormDefinition.json
@@ -112,15 +112,15 @@
               "name": "OpnVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "OPNSense Version to deploy",
-              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
-              "defaultValue": "23.7"
+              "toolTip": "OPNsense Releases. Latest: 24.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
+              "defaultValue": "24.1"
             },
             {
               "name": "WALinuxVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "Azure WALinux agent Version",
-              "toolTip": "Azure WALinux agent Releases. Only version number, dont add v at the begining. Latest: 2.9.0.4, 2.9.1.1 Reference: https://github.com/Azure/WALinuxAgent/releases",
-              "defaultValue": "2.9.1.1"
+              "toolTip": "Azure WALinux agent Releases. Only version number, dont add v at the begining. Latest: 2.10.0.8, 2.9.1.1 Reference: https://github.com/Azure/WALinuxAgent/releases",
+              "defaultValue": "2.10.0.8"
             },
             {
               "name": "DeployWindows",

--- a/scripts/configureopnsense.sh
+++ b/scripts/configureopnsense.sh
@@ -47,9 +47,9 @@ fi
 
 # 1. Package to get root certificate bundle from the Mozilla Project (FreeBSD)
 # 2. Install bash to support Azure Backup integration
-env IGNORE_OSVERSION=yes
-pkg bootstrap -f; pkg update -f
-env ASSUME_ALWAYS_YES=YES pkg install ca_root_nss && pkg install -y bash
+#env IGNORE_OSVERSION=yes
+#pkg bootstrap -f; pkg update -f
+#env ASSUME_ALWAYS_YES=YES pkg install ca_root_nss && pkg install -y bash
 
 #Download OPNSense Bootstrap and Permit Root Remote Login
 # fetch https://raw.githubusercontent.com/opnsense/update/master/src/bootstrap/opnsense-bootstrap.sh.in

--- a/scripts/configureopnsense.sh
+++ b/scripts/configureopnsense.sh
@@ -58,6 +58,11 @@ fetch https://raw.githubusercontent.com/opnsense/update/master/src/bootstrap/opn
 sed -i "" 's/#PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 #OPNSense
+# Due to a recent change in pkg the following commands no longer finish with status code 0
+#		pkg unlock -a
+#		pkg delete -fa
+# This resplace of set -e which force the script to finish in case of non status code 0 has to be inplace
+sed -i "" "s/set -e/#set -e/g" opnsense-bootstrap.sh.in
 sed -i "" "s/reboot/shutdown -r +1/g" opnsense-bootstrap.sh.in
 sh ./opnsense-bootstrap.sh.in -y -r "$2"
 

--- a/scripts/configureopnsense.sh
+++ b/scripts/configureopnsense.sh
@@ -74,7 +74,7 @@ python3 setup.py install --register-service --lnx-distro=freebsd --force
 cd ..
 
 # Fix waagent by replacing configuration settings
-ln -s /usr/local/bin/python3.9 /usr/local/bin/python
+ln -s /usr/local/bin/python3.11 /usr/local/bin/python
 ##sed -i "" 's/command_interpreter="python"/command_interpreter="python3"/' /etc/rc.d/waagent
 ##sed -i "" 's/#!\/usr\/bin\/env python/#!\/usr\/bin\/env python3/' /usr/local/sbin/waagent
 sed -i "" 's/ResourceDisk.EnableSwap=y/ResourceDisk.EnableSwap=n/' /etc/waagent.conf


### PR DESCRIPTION
Fixed a problem with FreeBSD 13.2

The commands "pkg unlock -a" and "pkg delete -fa" used by the OPNSense bootstrap was returning a exit status code different than 0 even when it was receiving a successful result.

I added a replace for the "set -e" to comment it out. That fixed the main problem where the bootscript was stopping unexpected:

########################################################
# sh ./opnsense-bootstrap.sh.in -y -r 24.1
This utility will attempt to turn this installation into the latest
OPNsense 24.1 release.  All packages will be deleted, the base
system and kernel will be replaced, and if all went well the system
will automatically shutdown -r +1.
 
/tmp/opnsense-bootstrap/core.tar.gz                   7648 kB   77 MBps    00s
pkg: 19 packages installed
azure-agent-2.2.54.2_1: already unlocked
########################################################

In the latest FreeBSD 13.2 Image it also updated Python from 3.9 to 3.11 which was causing the WAAGENT to fail.
This problem was fixed by adding the new version in the ln -s command.

Updated Bicep/Arm to the latest OPNSense and WAAGENT versions.